### PR TITLE
Add misc script to calc working time based on audit logs

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -21,9 +21,11 @@
     "jsr:@std/fs@^1.0.4": "1.0.5",
     "jsr:@std/io@0.225": "0.225.0",
     "jsr:@std/io@~0.224.9": "0.224.9",
+    "jsr:@std/json@0.223.0": "0.223.0",
     "jsr:@std/log@*": "0.224.9",
     "jsr:@std/log@~0.224.9": "0.224.9",
     "jsr:@std/path@~1.0.6": "1.0.7",
+    "jsr:@std/streams@0.223.0": "0.223.0",
     "jsr:@std/text@~1.0.7": "1.0.8",
     "jsr:@std/toml@*": "1.0.1",
     "jsr:@std/toml@^1.0.1": "1.0.1",
@@ -106,6 +108,9 @@
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
     },
+    "@std/json@0.223.0": {
+      "integrity": "9a4a255931dd0397924c6b10bb6a72fe3e28ddd876b981ada2e3b8dd0764163f"
+    },
     "@std/log@0.224.9": {
       "integrity": "419d04e4d93e6b1a0205ac3f94809621cfec3d328d09fec9ec59cafa3b3fcaee",
       "dependencies": [
@@ -116,6 +121,9 @@
     },
     "@std/path@1.0.7": {
       "integrity": "76a689e07f0e15dcc6002ec39d0866797e7156629212b28f27179b8a5c3b33a1"
+    },
+    "@std/streams@0.223.0": {
+      "integrity": "d6b28e498ced3960b04dc5d251f2dcfc1df244b5ec5a48dc23a8f9b490be3b99"
     },
     "@std/text@1.0.8": {
       "integrity": "40ba34caa095f393e78796e5eda37b8b4e2cc6cfd6f51f34658ad7487b1451e4"

--- a/misc/calc.ts
+++ b/misc/calc.ts
@@ -1,0 +1,122 @@
+import { TextLineStream } from "jsr:@std/streams@0.223.0/text-line-stream";
+import { JsonParseStream } from "jsr:@std/json@0.223.0/json-parse-stream";
+
+interface ResultByDate {
+  workTime: number; // ミリ秒
+  breakTime: number; // ミリ秒
+  lastStartTime: number | null; // ミリ秒
+  lastAfkTime: number | null; // ミリ秒
+  startTime: number | null; // ミリ秒
+  endTime: number | null; // ミリ秒
+}
+
+// 時間をXhXXm形式にフォーマットする
+const formatTime = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = Math.round(minutes % 60);
+  return `${hours}h${remainingMinutes.toString().padStart(2, "0")}m`;
+};
+
+// タイムスタンプを日本時間でフォーマットする
+const formatTimestamp = (timestamp: number | null): string | null => {
+  if (timestamp === null) return null;
+  const date = new Date(timestamp);
+  return date.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" }); // ローカルタイムを日本時間でフォーマット
+};
+
+const calculateTimeByDate = () => {
+  const result: Record<string, ResultByDate> = {};
+
+  return {
+    processEntry(entry: any) {
+      const date = entry.time.split(" ")[0]; // Extract date (YYYY-MM-DD)
+
+      if (!result[date]) {
+        result[date] = {
+          workTime: 0,
+          breakTime: 0,
+          lastStartTime: null,
+          lastAfkTime: null,
+          startTime: null,
+          endTime: null,
+        };
+      }
+
+      const currentTime = new Date(entry.time).getTime();
+
+      if (entry.status === "start") {
+        result[date].lastStartTime = currentTime;
+        result[date].startTime = currentTime; // 最初の勤務開始時間を記録
+      } else if (entry.status === "afk") {
+        if (result[date].lastStartTime !== null) {
+          // 休憩を始める時、働いた時間を計算する
+          result[date].workTime += currentTime - result[date].lastStartTime;
+        }
+        result[date].lastAfkTime = currentTime; // 離席時間を記録
+        result[date].lastStartTime = null; // 勤務中の時間をリセット
+      } else if (entry.status === "back") {
+        if (result[date].lastAfkTime !== null) {
+          // 戻った時に休憩時間を計算する
+          result[date].breakTime += currentTime - result[date].lastAfkTime;
+        }
+        result[date].lastStartTime = currentTime; // 勤務を再開
+        result[date].lastAfkTime = null; // 離席時間をリセット
+      } else if (entry.status === "end") {
+        if (result[date].lastStartTime !== null) {
+          // 勤務終了時に残っている勤務時間を加算
+          result[date].workTime += currentTime - result[date].lastStartTime;
+        }
+        result[date].endTime = currentTime; // 最後の勤務終了時間を記録
+      }
+    },
+    getResult() {
+      for (const key in result) {
+        if (
+          key in result && result[key].endTime == null &&
+          result[key].lastStartTime != null
+        ) {
+          const currentTime = new Date().getTime();
+          result[key].workTime += currentTime - result[key].lastStartTime;
+          result[key].endTime = currentTime;
+        }
+      }
+      return result;
+    },
+  };
+};
+
+// メインの処理
+const main = async () => {
+  const calculator = calculateTimeByDate();
+
+  // Denoでは、標準入力を逐次的に読み取る
+  const reader = Deno.stdin.readable
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new TextLineStream())
+    .pipeThrough(new JsonParseStream());
+
+  for await (const entry of reader) {
+    calculator.processEntry(entry);
+  }
+
+  const resultByDate = calculator.getResult();
+  const formatted = [];
+
+  // フォーマットして出力
+  for (const date in resultByDate) {
+    const workTimeInMinutes = resultByDate[date].workTime / 1000 / 60;
+    const breakTimeInMinutes = resultByDate[date].breakTime / 1000 / 60;
+
+    formatted.push({
+      date,
+      workTime: formatTime(workTimeInMinutes),
+      breakTime: formatTime(breakTimeInMinutes),
+      startTime: formatTimestamp(resultByDate[date].startTime),
+      endTime: formatTimestamp(resultByDate[date].endTime),
+    });
+  }
+
+  console.log(JSON.stringify(formatted, null, 2)); // 結果を整形して出力
+};
+
+main();


### PR DESCRIPTION
Usage example

```bash
ls -t1 ${XDG_DATA_HOME:-~/.local/share}/st/ | head -n 1 | xargs -I_ cat ${XDG_DATA_HOME:-~/.local/share}/st/_ | deno run -A calc.ts  
```